### PR TITLE
catkin_make build error fix

### DIFF
--- a/arachnida_ws/src/arachnida/CMakeLists.txt
+++ b/arachnida_ws/src/arachnida/CMakeLists.txt
@@ -109,6 +109,13 @@ add_executable(gaitEnergeticsNode src/gait_energetics/gait_energetics.cpp
               src/gait_energetics/main.cpp)
 
 
+add_dependencies(velodyneReaderNode ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS}
+)
+
+add_dependencies(pathPlanNode ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS}
+)
+
+
 target_link_libraries(publisher_sample_node
   ${catkin_LIBRARIES}
 )


### PR DESCRIPTION
catkin_make does not need to be called 3 times to build arachnida_ws anymore